### PR TITLE
Use previousnext/mysql containers for utility scripts

### DIFF
--- a/pkg/controller/backup/backup_controller.go
+++ b/pkg/controller/backup/backup_controller.go
@@ -116,7 +116,7 @@ func (r *ReconcileBackup) Reconcile(request reconcile.Request) (reconcile.Result
 		CPU:         "100m",
 		Memory:      "512Mi",
 		ResticImage: "docker.io/restic/restic:0.9.5",
-		MySQLImage:  "docker.io/library/mariadb:10",
+		MySQLImage:  "previousnext/mysql",
 		WorkingDir:  "/home/shepherd",
 		Tags:        []string{},
 	}

--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -133,7 +133,7 @@ func (r *ReconcileRestore) Reconcile(request reconcile.Request) (reconcile.Resul
 		CPU:         "100m",
 		Memory:      "512Mi",
 		ResticImage: "docker.io/restic/restic:0.9.5",
-		MySQLImage:  "docker.io/library/mariadb:10",
+		MySQLImage:  "previousnext/mysql",
 		WorkingDir:  "/home/shepherd",
 		Tags:        []string{},
 	}

--- a/pkg/utils/restic/pod_test.go
+++ b/pkg/utils/restic/pod_test.go
@@ -159,10 +159,10 @@ func TestPodSpecBackup(t *testing.T) {
 				},
 				WorkingDir: "/home/test",
 				Command: []string{
-					"/bin/sh", "-c",
+					"database-backup",
 				},
 				Args: []string{
-					"mysqldump --single-transaction --host=\"$DATABASE_HOST\" --user=\"$DATABASE_USER\" --password=\"$DATABASE_PASSWORD\" --port=\"$DATABASE_PORT\" \"$DATABASE_NAME\" > \"mysql/mysql1.sql\"",
+					"mysql/mysql1.sql",
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -355,10 +355,10 @@ func TestPodSpecRestore(t *testing.T) {
 				Resources:  resources,
 				WorkingDir: "/home/test",
 				Command: []string{
-					"/bin/sh", "-c",
+					"database-restore",
 				},
 				Args: []string{
-					"mysql --user=${DATABASE_USER} --password=${DATABASE_PASSWORD} --host=${DATABASE_HOST} --port=${DATABASE_PORT} ${DATABASE_NAME} < ./mysql/mysql1.sql",
+					"mysql/mysql1.sql",
 				},
 				Env: []corev1.EnvVar{
 					{


### PR DESCRIPTION
Changes backup and restore to use the following scripts:

https://github.com/previousnext/mysql-toolkit/blob/master/containers/mysql/scripts/database-backup.sh
https://github.com/previousnext/mysql-toolkit/blob/master/containers/mysql/scripts/database-restore.sh

This gives us db dropping before restoring for free