### PR TITLE
Use --quiet param in restic dump command

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/universityofadelaide/shepherd-operator/pkg/apis"
 	"github.com/universityofadelaide/shepherd-operator/pkg/controller"

--- a/pkg/utils/restic/pod.go
+++ b/pkg/utils/restic/pod.go
@@ -211,7 +211,7 @@ func PodSpecRestore(restore *extensionv1.Restore, dc *osv1.DeploymentConfig, res
 			},
 			Args: []string{
 				helper.TprintfMustParse(
-					"restic dump {{.ResticId}} /{{.SQLPath}} > ./{{.SQLPath}}",
+					"restic dump --quiet {{.ResticId}} /{{.SQLPath}} > ./{{.SQLPath}}",
 					map[string]interface{}{
 						"ResticId": resticId,
 						"SQLPath":  fmt.Sprintf("mysql/%s.sql", mysqlName),

--- a/pkg/utils/restic/pod_test.go
+++ b/pkg/utils/restic/pod_test.go
@@ -376,7 +376,7 @@ func TestPodSpecRestore(t *testing.T) {
 					"/bin/sh", "-c",
 				},
 				Args: []string{
-					"restic dump abcd1234 /mysql/mysql1.sql > ./mysql/mysql1.sql",
+					"restic dump --quiet abcd1234 /mysql/mysql1.sql > ./mysql/mysql1.sql",
 				},
 				Env: []corev1.EnvVar{
 					{


### PR DESCRIPTION
Restic dump will output a line about using a cache which can pollute the mysql dump, using this param solves that issue.

I think the only reason we're not seeing this on your platform is due to it being unable to write the cache dir and the output going to stderr