### PR TITLE
SAPP-1172: Disable cache during restore

### DIFF
--- a/pkg/utils/restic/pod.go
+++ b/pkg/utils/restic/pod.go
@@ -347,7 +347,7 @@ func PodSpecRestore(restore *extensionv1.Restore, dc *osv1.DeploymentConfig, res
 		},
 		Args: []string{
 			helper.TprintfMustParse(
-				"drush -r {{.WebDir}}/web cr && drush -r {{.WebDir}}/web -y updb && robo config:import-plus && drush -r {{.WebDir}}/web cr",
+				"export REDIS_ENABLED=0 && export MEMCACHE_ENABLED=0 && drush -r {{.WebDir}}/web cr && drush -r {{.WebDir}}/web -y updb && robo config:import-plus && drush -r {{.WebDir}}/web cr",
 				map[string]interface{}{
 					"WebDir": WebDirectory,
 				},

--- a/pkg/utils/restic/pod_test.go
+++ b/pkg/utils/restic/pod_test.go
@@ -546,7 +546,7 @@ func TestPodSpecRestore(t *testing.T) {
 					"/bin/sh", "-c",
 				},
 				Args: []string{
-					"drush -r /code/web cr && drush -r /code/web -y updb && robo config:import-plus && drush -r /code/web cr",
+					"export REDIS_ENABLED=0 && export MEMCACHE_ENABLED=0 && drush -r /code/web cr && drush -r /code/web -y updb && robo config:import-plus && drush -r /code/web cr",
 				},
 				Env: []corev1.EnvVar{
 					{


### PR DESCRIPTION
Fixes issues like:
```
[warning] Redis::connect(): php_network_getaddresses: getaddrinfo failed: No address associated with hostname PhpRedis.php:28[warning] Redis::connect(): connect() failed: php_network_getaddresses: getaddrinfo failed: No address associated with hostname PhpRedis.php:28

In PhpRedis.php line 41:

Redis server went away  
```
When restoring from Redis -> Memcache.