### PR TITLE
Successful job is successful, even if it failed.

### DIFF
--- a/pkg/controller/restore/restore_controller.go
+++ b/pkg/controller/restore/restore_controller.go
@@ -215,8 +215,7 @@ func (r *ReconcileRestore) Reconcile(request reconcile.Request) (reconcile.Resul
 	} else {
 		if job.Status.Succeeded > 0 {
 			status.Phase = v1.PhaseCompleted
-		}
-		if job.Status.Failed > 0 {
+		} else if job.Status.Failed > 0 {
 			status.Phase = v1.PhaseFailed
 		}
 	}


### PR DESCRIPTION
Ran into this bug upgrading sites...

Running a restore, I noticed the following:

Job
```
status:
  completionTime: 2021-08-03T07:31:17Z
  conditions:
  - lastProbeTime: 2021-08-03T07:31:17Z
    lastTransitionTime: 2021-08-03T07:31:17Z
    status: "True"
    type: Complete
  failed: 1
  startTime: 2021-08-03T07:22:32Z
  succeeded: 1
```

Restore
```
status:
  completionTime: 2021-08-03T07:31:17Z
  phase: Failed
  startTime: 2021-08-03T07:22:32Z
```

Reason being the logic changed in this MR.

An alternative approach would be to add another state for "Completed with errors"? But not sure it's needed.
I.e. A job can fail (1 pod fails), but it retries and succeeds on the next attempt (which is what happened).