### PR TITLE
Re-add sync flag.

### DIFF
--- a/controllers/extension/sync/backup/controller.go
+++ b/controllers/extension/sync/backup/controller.go
@@ -94,6 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			Labels: map[string]string{
 				"site":        sync.Spec.Site,
 				"environment": sync.Spec.BackupEnv,
+				"is-sync":     "1",
 			},
 		},
 		Spec: sync.Spec.BackupSpec,


### PR DESCRIPTION
This got removed in ee8180eef5752088e7ba5a0c440099982d08c866 as part of moving from restic, but we use the label to display a different type for backups created from a sync.